### PR TITLE
Fix: Allow max_results higher than 10in config

### DIFF
--- a/src/main/java/io/github/misode/invrestore/commands/InvRestoreCommand.java
+++ b/src/main/java/io/github/misode/invrestore/commands/InvRestoreCommand.java
@@ -151,10 +151,11 @@ public class InvRestoreCommand {
                     false
             );
         });
-        if (snapshots.size() > 5) {
-            ctx.sendSuccess(() -> (Component.literal("and " + (snapshots.size() - 5) + " more...")
-                    .withStyle(Styles.LIST_DEFAULT)),
-                    false);
+        int maxResults = config.maxResults();
+        if (snapshots.size() > maxResults) {
+                ctx.sendSuccess(() -> (Component.literal("and " + (snapshots.size() - maxResults) + "more...")
+                .withStyle(Styles.LIST_DEFAULT)),
+                false);
         }
         return snapshots.size();
     }

--- a/src/main/java/io/github/misode/invrestore/config/InvRestoreConfig.java
+++ b/src/main/java/io/github/misode/invrestore/config/InvRestoreConfig.java
@@ -65,7 +65,7 @@ public record InvRestoreConfig(QueryResults queryResults, StoreLimits storeLimit
     public record QueryResults(int maxResults, ZoneId defaultZone, String fullTimeFormat) {
         public static final QueryResults DEFAULT = new QueryResults(5, ZoneId.of("UTC"), "yyyy-MM-dd HH:mm:ss (z)");
         public static final Codec<QueryResults> CODEC = RecordCodecBuilder.create(b -> b.group(
-                optionalField(Codec.intRange(1, 10), "max_results", DEFAULT.maxResults).forGetter(QueryResults::maxResults),
+                optionalField(Codec.intRange(1, 1000), "max_results", DEFAULT.maxResults).forGetter(QueryResults::maxResults),
                 optionalField(Codec.STRING.xmap(ZoneId::of, ZoneId::toString), "default_timezone", DEFAULT.defaultZone).forGetter(QueryResults::defaultZone),
                 optionalField(Codec.STRING.comapFlatMap(s -> {
                     try {


### PR DESCRIPTION
The config.json Parser was limited to the [1,10] range. Now it has been increased to [1,1000], allowing higher values.
The limit to the results shown in chat were also limited to a maximum of 5 results, hardcoded. It now exhibits correctly the amount of max_results set in config.json  

Setting up max_results as 30:
![Imagem do WhatsApp de 2025-07-12 à(s) 04 14 03_d6012d45](https://github.com/user-attachments/assets/9a4f4d34-9d61-4d83-ab11-252eedbc4fa5)

