### PR TITLE
Fixes running click actions off-thread

### DIFF
--- a/src/main/java/io/github/misode/invrestore/mixin/ServerCommonPacketListenerImplMixin.java
+++ b/src/main/java/io/github/misode/invrestore/mixin/ServerCommonPacketListenerImplMixin.java
@@ -13,7 +13,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ServerCommonPacketListenerImpl.class)
 public abstract class ServerCommonPacketListenerImplMixin {
-    @Inject(method = "handleCustomClickAction", at = @At(value = "HEAD"), cancellable = true)
+    @Inject(
+        method = "handleCustomClickAction",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/MinecraftServer;handleCustomClickAction(Lnet/minecraft/resources/Identifier;Ljava/util/Optional;)V"
+        ),
+        cancellable = true
+    )
     private void handleCustomClickAction(ServerboundCustomClickActionPacket packet, CallbackInfo ci) {
         if (!packet.id().getNamespace().equals(InvRestore.MOD_ID)) {
             return;


### PR DESCRIPTION
Fixes the underlying issue causing #25

Previously `InvRestore#handleCustomClickAction` would run off the main thread, which allowed players to be teleported off-thread, which allows for all kinds of race conditions to happen (like trying to load chunks off-thread). ChunkDebug simply enforces that chunks are loaded on the correct thread which caught this error.